### PR TITLE
Fix stale OAuth token in batch worker

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -108,7 +108,7 @@ def main():
             thread_id,
             channel,
             twitch["client_id"],
-            token_manager.get_token(),  # Pass OAuth token for message deletion
+            token_manager,  # pass manager so worker can refresh token
             batch_interval
         ),
         daemon=True


### PR DESCRIPTION
## Summary
- pass `TwitchOAuthTokenManager` to `batch_worker`
- fetch a fresh token for each moderation batch and channel info request

## Testing
- `python -m py_compile bot.py irc_client.py moderation.py twitch_auth.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68685d4affe883209a2d18b958f3cdf5