### PR TITLE
Add token-based OpenAI rate limiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ api_key: "your-openai-api-key"
 assistant_id: "your-assistant-id"
 model: "gpt-4o-mini"
 batch_interval: 10
+tokens_per_minute: 20000
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697
@@ -75,6 +76,7 @@ See `config.yaml` for all configuration options. Key settings:
 
 - `batch_interval`: Time in seconds between moderation batches
 - `model`: OpenAI model to use for moderation
+- `tokens_per_minute`: Rate limit for OpenAI API usage
 - Twitch credentials and connection settings
 
 ## Contributing

--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ api_key: "sk-get-your-own"
 assistant_id: "make-your-own"
 model: "gpt-4o-mini"
 batch_interval: 10
+tokens_per_minute: 20000
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 irc
 openai
 cryptography
+tiktoken

--- a/token_utils.py
+++ b/token_utils.py
@@ -1,0 +1,56 @@
+import threading
+import time
+from typing import Optional
+
+try:
+    import tiktoken
+except ImportError:  # pragma: no cover - tiktoken is optional at runtime
+    tiktoken = None
+
+_DEFAULT_ENCODING = None
+
+if tiktoken is not None:
+    try:
+        _DEFAULT_ENCODING = tiktoken.get_encoding("cl100k_base")
+    except Exception:
+        _DEFAULT_ENCODING = None
+
+
+def count_tokens(text: str, model: Optional[str] = None) -> int:
+    """Return the number of tokens for ``text`` using ``tiktoken``."""
+    if tiktoken is None:
+        return len(text.split())
+    try:
+        enc = tiktoken.encoding_for_model(model) if model else _DEFAULT_ENCODING
+        if enc is None:
+            enc = tiktoken.get_encoding("cl100k_base")
+        return len(enc.encode(text))
+    except Exception:
+        return len(text.split())
+
+
+class TokenBucket:
+    """Simple token bucket rate limiter."""
+
+    def __init__(self, tokens_per_minute: int):
+        self.capacity = max(1, tokens_per_minute)
+        self.tokens = float(self.capacity)
+        self.rate = float(tokens_per_minute) / 60.0
+        self.timestamp = time.time()
+        self.lock = threading.Lock()
+
+    def consume(self, amount: int):
+        """Consume ``amount`` tokens, sleeping if necessary."""
+        with self.lock:
+            now = time.time()
+            elapsed = now - self.timestamp
+            self.timestamp = now
+            self.tokens = min(self.capacity, self.tokens + elapsed * self.rate)
+            if amount > self.tokens:
+                wait_time = (amount - self.tokens) / self.rate
+                self.tokens = 0
+            else:
+                wait_time = 0
+                self.tokens -= amount
+        if wait_time > 0:
+            time.sleep(wait_time)


### PR DESCRIPTION
## Summary
- add `TokenBucket` rate limiter and `count_tokens` helpers
- enforce token bucket in `moderate_batch` so OpenAI API usage is throttled
- pass rate limit config through bot and worker threads
- document `tokens_per_minute` in README and default config
- require `tiktoken` package for tokenization

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_686946b1e7c08320b6947e0e38daa3e2