### PR TITLE
Include prompt tokens in count

### DIFF
--- a/token_utils.py
+++ b/token_utils.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import time
 from typing import Optional
@@ -8,6 +9,9 @@ except ImportError:  # pragma: no cover - tiktoken is optional at runtime
     tiktoken = None
 
 _DEFAULT_ENCODING = None
+PROMPT_FILE = os.path.join(os.path.dirname(__file__), "prompt.txt")
+PROMPT_TOKENS = 0
+PROMPT_TEXT = ""
 
 if tiktoken is not None:
     try:
@@ -15,18 +19,34 @@ if tiktoken is not None:
     except Exception:
         _DEFAULT_ENCODING = None
 
+    # Pre-calculate tokens for the base prompt
+    try:
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            PROMPT_TEXT = f.read()
+        enc = _DEFAULT_ENCODING or tiktoken.get_encoding("cl100k_base")
+        PROMPT_TOKENS = len(enc.encode(PROMPT_TEXT))
+    except Exception:
+        PROMPT_TOKENS = len(PROMPT_TEXT.split()) if PROMPT_TEXT else 0
+else:
+    try:
+        with open(PROMPT_FILE, "r", encoding="utf-8") as f:
+            PROMPT_TEXT = f.read()
+        PROMPT_TOKENS = len(PROMPT_TEXT.split())
+    except Exception:
+        PROMPT_TOKENS = 0
+
 
 def count_tokens(text: str, model: Optional[str] = None) -> int:
-    """Return the number of tokens for ``text`` using ``tiktoken``."""
+    """Return the number of tokens for ``text`` plus the base prompt."""
     if tiktoken is None:
-        return len(text.split())
+        return len(text.split()) + PROMPT_TOKENS
     try:
         enc = tiktoken.encoding_for_model(model) if model else _DEFAULT_ENCODING
         if enc is None:
             enc = tiktoken.get_encoding("cl100k_base")
-        return len(enc.encode(text))
+        return len(enc.encode(text)) + PROMPT_TOKENS
     except Exception:
-        return len(text.split())
+        return len(text.split()) + PROMPT_TOKENS
 
 
 class TokenBucket:


### PR DESCRIPTION
## Summary
- account for `prompt.txt` when computing token usage

## Testing
- `python -m py_compile token_utils.py bot.py irc_client.py moderation.py twitch_auth.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68694a943f2083208473b687ee1803a5