### PR TITLE
Make moderation timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ assistant_id: "your-assistant-id"
 model: "gpt-4o-mini"
 batch_interval: 10
 tokens_per_minute: 20000
+moderation_timeout: 60
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697
@@ -77,6 +78,7 @@ See `config.yaml` for all configuration options. Key settings:
 - `batch_interval`: Time in seconds between moderation batches
 - `model`: OpenAI model to use for moderation
 - `tokens_per_minute`: Rate limit for OpenAI API usage
+- `moderation_timeout`: Timeout in seconds for each moderation batch
 - Twitch credentials and connection settings
 
 ## Contributing

--- a/bot.py
+++ b/bot.py
@@ -84,6 +84,7 @@ def main():
     model = config.get("model", "gpt-4o-mini")
     batch_interval = config.get("batch_interval", 2)
     tokens_per_minute = config.get("tokens_per_minute", 20000)
+    moderation_timeout = config.get("moderation_timeout", 60)
     channel = twitch["channel"]
 
     # --- Token manager ---
@@ -129,7 +130,8 @@ def main():
             thread_id,
             twitch["client_id"],
             token_manager,
-            token_bucket
+            token_bucket,
+            moderation_timeout
         ),
         daemon=True
     )

--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,7 @@ assistant_id: "make-your-own"
 model: "gpt-4o-mini"
 batch_interval: 10
 tokens_per_minute: 20000
+moderation_timeout: 60
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697


### PR DESCRIPTION
## Summary
- allow configuring moderation timeout
- pass the configured value to run worker
- document new option in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68694c1e4ebc8320975854bb306ed787