### PR TITLE
Handle rate limit retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ model: "gpt-4o-mini"
 batch_interval: 10
 tokens_per_minute: 20000
 moderation_timeout: 60
+max_openai_content_size: 256000
+max_rate_limit_retries: 3
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697
@@ -79,6 +81,8 @@ See `config.yaml` for all configuration options. Key settings:
 - `model`: OpenAI model to use for moderation
 - `tokens_per_minute`: Rate limit for OpenAI API usage
 - `moderation_timeout`: Timeout in seconds for each moderation batch
+- `max_openai_content_size`: Maximum JSON payload size sent to OpenAI
+- `max_rate_limit_retries`: How many times to retry on rate limits
 - Twitch credentials and connection settings
 
 ## Contributing

--- a/bot.py
+++ b/bot.py
@@ -33,7 +33,7 @@ import json
 
 from twitch_auth import TwitchOAuthTokenManager
 from irc_client import run_irc_forever
-from moderation import message_queue, batch_worker, run_worker, loss_report
+from moderation import message_queue, batch_worker, run_worker, loss_report, configure_limits
 from token_utils import TokenBucket
 
 try:
@@ -85,6 +85,8 @@ def main():
     batch_interval = config.get("batch_interval", 2)
     tokens_per_minute = config.get("tokens_per_minute", 20000)
     moderation_timeout = config.get("moderation_timeout", 60)
+    max_openai_content_size = config.get("max_openai_content_size", 256000)
+    max_rate_limit_retries = config.get("max_rate_limit_retries", 3)
     channel = twitch["channel"]
 
     # --- Token manager ---
@@ -97,6 +99,8 @@ def main():
     client_ai = OpenAI(api_key=api_key)
 
     token_bucket = TokenBucket(tokens_per_minute)
+
+    configure_limits(max_openai_content_size, max_rate_limit_retries)
 
     # --- Persistent thread ID ---
     thread_id = get_thread_id(client_ai, channel)

--- a/config.yaml
+++ b/config.yaml
@@ -4,6 +4,8 @@ model: "gpt-4o-mini"
 batch_interval: 10
 tokens_per_minute: 20000
 moderation_timeout: 60
+max_openai_content_size: 256000
+max_rate_limit_retries: 3
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697


### PR DESCRIPTION
## Summary
- parse retry delay from rate limit error messages
- retry moderation batches when the OpenAI API hits rate limits
- allow configuring openai payload size and retry limit via config file

## Testing
- `python -m py_compile moderation.py bot.py token_utils.py irc_client.py twitch_auth.py utils.py`
- `pip install --quiet flake8` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68694e93df988320b937d037884edfae