### PR TITLE
Add async escalation worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ An AI-powered moderation bot for Twitch chat that uses OpenAI's GPT models to de
 - AI-powered content analysis using OpenAI's GPT models
 - Configurable moderation thresholds based on user roles (mod, VIP, subscriber)
 - Automatic message deletion for violations
+- Escalation assistant runs in a separate thread to track users across threads and issue timeouts or bans without blocking regular moderation
 - Detailed logging of chat and moderation actions
 - Support for OAuth authentication with Twitch
 - Batch processing to optimize API usage
@@ -31,6 +32,7 @@ pip install -r requirements.txt
 ```yaml
 api_key: "your-openai-api-key"
 assistant_id: "your-assistant-id"
+escalation_assistant_id: "your-escalation-assistant-id"
 model: "gpt-4o-mini"
 batch_interval: 10
 tokens_per_minute: 20000
@@ -81,6 +83,7 @@ See `config.yaml` for all configuration options. Key settings:
 - `model`: OpenAI model to use for moderation
 - `tokens_per_minute`: Rate limit for OpenAI API usage
 - `moderation_timeout`: Timeout in seconds for each moderation batch
+- `escalation_assistant_id`: Assistant used to analyze repeated offenses
 - `max_openai_content_size`: Maximum JSON payload size sent to OpenAI
 - `max_rate_limit_retries`: How many times to retry on rate limits
 - Twitch credentials and connection settings

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ An AI-powered moderation bot for Twitch chat that uses OpenAI's GPT models to de
 - Configurable moderation thresholds based on user roles (mod, VIP, subscriber)
 - Automatic message deletion for violations
 - Escalation assistant runs in a separate thread to track users across threads and issue timeouts or bans without blocking regular moderation
+- Multiple violations from the same user are grouped into a single escalation request
 - Detailed logging of chat and moderation actions
 - Support for OAuth authentication with Twitch
 - Batch processing to optimize API usage

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 api_key: "sk-get-your-own"      # OpenAI API key, used for the chat completion API
 assistant_id: "make-your-own"   # OpenAI Assistant ID, used for the chat completion API
+escalation_assistant_id: "make-your-own-escalation" # OpenAI Assistant ID for escalation checks
 model: "gpt-4o-mini"            # OpenAI model to use. I like 4o-mimi. It's not that serious.
 batch_interval: 10              # how often to process batches of messages in seconds
 tokens_per_minute: 200000       # your OpenAI API token per minute rate limit

--- a/escalate.py
+++ b/escalate.py
@@ -1,0 +1,208 @@
+import json
+import time
+import queue
+import requests
+from utils import load_json, save_json
+
+THREADS_FILE = "user_threads.json"
+
+# Queue for escalation tasks
+escalate_queue = queue.Queue()
+
+# Global per-user thread mapping
+user_threads = load_json(THREADS_FILE)
+
+
+def load_user_threads():
+    return load_json(THREADS_FILE)
+
+
+def save_user_threads(data):
+    save_json(THREADS_FILE, data)
+
+
+def get_user_thread_id(openai_client, username, thread_map):
+    user_key = username.lower()
+    if user_key in thread_map:
+        return thread_map[user_key]
+    thread = openai_client.beta.threads.create()
+    thread_map[user_key] = thread.id
+    save_user_threads(thread_map)
+    print(f"[THREAD][USER] Created new thread for {user_key}: {thread.id}")
+    return thread.id
+
+
+def wait_for_run_completion(openai_client, thread_id, run, poll_interval=5, timeout=120):
+    start = time.time()
+    while True:
+        try:
+            status = openai_client.beta.threads.runs.retrieve(run.id, thread_id=thread_id)
+            if status.status == "completed":
+                return status
+            if status.status in ("failed", "cancelled", "expired"):
+                print(f"[ERROR][ESCALATION] Run status for {run.id} is {status.status}")
+                return status
+            if time.time() - start > timeout:
+                print(f"[ERROR][ESCALATION] Timed out waiting for run {run.id} on thread {thread_id}")
+                return status
+            time.sleep(poll_interval)
+        except Exception as e:
+            print(f"[ERROR][ESCALATION] Exception while waiting for run: {e}")
+            return None
+
+
+def escalate_user_action(openai_client, assistant_id, model, username, violation, thread_map, poll_interval=5, timeout=120):
+    thread_id = get_user_thread_id(openai_client, username, thread_map)
+    try:
+        openai_client.beta.threads.messages.create(
+            thread_id=thread_id,
+            role="user",
+            content=json.dumps(violation),
+        )
+        run = openai_client.beta.threads.runs.create(
+            thread_id=thread_id,
+            assistant_id=assistant_id,
+            model=model,
+        )
+    except Exception as e:
+        print(f"[ERROR][ESCALATION] Exception starting run: {e}")
+        return None
+
+    status = wait_for_run_completion(openai_client, thread_id, run, poll_interval, timeout)
+    if not status or status.status != "completed":
+        return None
+    try:
+        result = openai_client.beta.threads.messages.list(thread_id=thread_id)
+        latest = result.data[0].content[0].text.value if result.data else ""
+        return latest
+    except Exception as e:
+        print(f"[ERROR][ESCALATION] Exception fetching result: {e}")
+        return None
+
+
+def parse_escalation_result(text):
+    if not text:
+        return {}
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            return data
+    except Exception as e:
+        print(f"[ERROR][ESCALATION] Failed to parse escalation result: {e}")
+    return {}
+
+
+def lookup_user_id(username, token, client_id):
+    url = f"https://api.twitch.tv/helix/users?login={username}"
+    headers = {
+        "Client-ID": client_id,
+        "Authorization": f"Bearer {token}",
+    }
+    try:
+        resp = requests.get(url, headers=headers, timeout=10)
+        if resp.status_code == 200 and resp.json().get("data"):
+            return resp.json()["data"][0]["id"]
+        print(f"[TWITCH][ERROR] User lookup failed for {username}: {resp.status_code} - {resp.text}")
+    except Exception as e:
+        print(f"[TWITCH][ERROR] Exception looking up user {username}: {e}")
+    return None
+
+
+def timeout_user(broadcaster_id, moderator_id, user_id, token, client_id, duration, reason="Timeout by moderation bot"):
+    url = "https://api.twitch.tv/helix/moderation/bans"
+    headers = {
+        "Client-ID": client_id,
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    params = {
+        "broadcaster_id": broadcaster_id,
+        "moderator_id": moderator_id,
+    }
+    data = {"data": {"user_id": user_id, "duration": int(duration), "reason": reason}}
+    try:
+        resp = requests.post(url, headers=headers, params=params, json=data, timeout=10)
+        if resp.status_code in (200, 201, 204):
+            print(f"[TWITCH] Timed out user {user_id} for {duration}s")
+            return True
+        print(f"[TWITCH][ERROR] Failed to timeout {user_id}: {resp.status_code} - {resp.text}")
+    except Exception as e:
+        print(f"[TWITCH][ERROR] Exception timing out {user_id}: {e}")
+    return False
+
+
+def ban_user(broadcaster_id, moderator_id, user_id, token, client_id, reason="Banned by moderation bot"):
+    url = "https://api.twitch.tv/helix/moderation/bans"
+    headers = {
+        "Client-ID": client_id,
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+    params = {
+        "broadcaster_id": broadcaster_id,
+        "moderator_id": moderator_id,
+    }
+    data = {"data": {"user_id": user_id, "reason": reason}}
+    try:
+        resp = requests.post(url, headers=headers, params=params, json=data, timeout=10)
+        if resp.status_code in (200, 201, 204):
+            print(f"[TWITCH] Banned user {user_id}")
+            return True
+        print(f"[TWITCH][ERROR] Failed to ban {user_id}: {resp.status_code} - {resp.text}")
+    except Exception as e:
+        print(f"[TWITCH][ERROR] Exception banning {user_id}: {e}")
+    return False
+
+
+def escalate_worker(stop_event, openai_client, assistant_id, model, token_manager, client_id):
+    """Background worker to process escalation tasks without blocking moderation."""
+    while not stop_event.is_set() or not escalate_queue.empty():
+        try:
+            task = escalate_queue.get(timeout=1)
+        except queue.Empty:
+            continue
+
+        username = task.get("username")
+        violation = task.get("violation")
+        broadcaster_id = task.get("broadcaster_id")
+        moderator_id = task.get("moderator_id")
+
+        try:
+            result_text = escalate_user_action(
+                openai_client,
+                assistant_id,
+                model,
+                username,
+                violation,
+                user_threads,
+            )
+            result = parse_escalation_result(result_text)
+            action = (result.get("action") or "").lower()
+            if action in {"timeout", "ban"} and username:
+                user_id = lookup_user_id(username, token_manager.get_token(), client_id)
+                if user_id:
+                    if action == "timeout":
+                        duration = int(result.get("duration", 600))
+                        timeout_user(
+                            broadcaster_id,
+                            moderator_id,
+                            user_id,
+                            token_manager.get_token(),
+                            client_id,
+                            duration,
+                            result.get("reason", ""),
+                        )
+                    else:
+                        ban_user(
+                            broadcaster_id,
+                            moderator_id,
+                            user_id,
+                            token_manager.get_token(),
+                            client_id,
+                            result.get("reason", ""),
+                        )
+            save_user_threads(user_threads)
+        except Exception as e:
+            print(f"[ERROR][ESCALATE_WORKER] {e}")
+        finally:
+            escalate_queue.task_done()


### PR DESCRIPTION
## Summary
- process user escalation actions in a dedicated worker thread
- start/stop the escalation thread from `bot.py`
- queue flagged messages so moderation isn't blocked
- document that escalation runs asynchronously

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686abc0bbe8c8320a54a6a250fc412cc