### PR TITLE
Fix Twitch API parameter errors

### DIFF
--- a/escalate.py
+++ b/escalate.py
@@ -202,8 +202,8 @@ def warn_user(broadcaster_id, moderator_id, user_id, token, client_id, reason="W
     return False
 
 
-def send_chat_message(broadcaster_id, moderator_id, token, client_id, message):
-    """Send a chat message as the moderator."""
+def send_chat_message(broadcaster_id, sender_id, token, client_id, message):
+    """Send a chat message as ``sender_id``."""
     url = "https://api.twitch.tv/helix/chat/messages"
     headers = {
         "Client-ID": client_id,
@@ -212,7 +212,7 @@ def send_chat_message(broadcaster_id, moderator_id, token, client_id, message):
     }
     params = {
         "broadcaster_id": broadcaster_id,
-        "moderator_id": moderator_id,
+        "sender_id": sender_id,
     }
     data = {"message": message}
     try:

--- a/twitch_auth.py
+++ b/twitch_auth.py
@@ -82,7 +82,15 @@ class TwitchOAuthTokenManager:
     AUTH_URL = "https://id.twitch.tv/oauth2/authorize"
     TOKEN_URL = "https://id.twitch.tv/oauth2/token"
     REDIRECT_URI = "https://localhost:8443/callback"
-    SCOPE = "chat:read user:read:chat moderator:manage:chat_messages"
+    # Required scopes to run the moderation bot. These allow reading chat,
+    # sending messages as the authenticated user, and managing bans/timeouts.
+    SCOPE = (
+        "chat:read "
+        "user:read:chat "
+        "user:write:chat "
+        "moderator:manage:chat_messages "
+        "moderator:manage:banned_users"
+    )
 
     def __init__(self, client_id: str, client_secret: str):
         self.client_id = client_id


### PR DESCRIPTION
## Summary
- fix OAuth scopes required for banning and chat messages
- correct Twitch send chat message parameter

## Testing
- `python -m py_compile escalate.py twitch_auth.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c3a6b671c83209e117e1c12bfb63f