### PR TITLE
Enable parallel moderation worker threads

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -36,7 +36,7 @@ from irc_client import run_irc_forever
 from moderation import (
     message_queue,
     batch_worker,
-    run_worker,
+    run_manager,
     loss_report,
     configure_limits,
 )
@@ -109,7 +109,7 @@ def main():
     batch_thread.start()
 
     run_thread = threading.Thread(
-        target=run_worker,
+        target=run_manager,
         args=(
             stop_event,
             client_ai,
@@ -119,6 +119,7 @@ def main():
             twitch["client_id"],
             token_manager,
             token_bucket,
+            batch_interval,
             moderation_timeout,
         ),
     )


### PR DESCRIPTION
## Summary
- add `run_manager` to spawn short-lived `run_worker` threads
- modify `run_worker` to process a single batch
- use new `run_manager` in `bot.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686c63011284832098b3f8a6cf2e09cd