### PR TITLE
Add optional streaming mode for moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ tokens_per_minute: 20000
 moderation_timeout: 60
 max_openai_content_size: 256000
 max_rate_limit_retries: 3
+use_stream: true
 twitch:
   server: "irc.chat.twitch.tv"
   port: 6697
@@ -57,6 +58,12 @@ Start the bot:
 python bot.py [-v|-vv]
 ```
 Use `-v` to print informational messages and `-vv` to include OAuth debug output.
+
+### Streaming mode
+
+Set `use_stream: true` in `config.yaml` to stream run events from OpenAI instead of polling.
+Streaming can reduce wait time for large runs and provides immediate feedback as
+messages are processed.
 
 On first run, the bot will:
 1. Generate required SSL certificates for OAuth
@@ -89,6 +96,7 @@ See `config.yaml` for all configuration options. Key settings:
 - `escalation_assistant_id`: Assistant used to analyze repeated offenses
 - `max_openai_content_size`: Maximum JSON payload size sent to OpenAI
 - `max_rate_limit_retries`: How many times to retry on rate limits
+- `use_stream`: Enable streaming of run events instead of polling
 - Twitch credentials and connection settings
 
 ## Contributing

--- a/bot.py
+++ b/bot.py
@@ -74,6 +74,7 @@ def main():
     moderation_timeout = config.get("moderation_timeout", 60)
     max_openai_content_size = config.get("max_openai_content_size", 256000)
     max_rate_limit_retries = config.get("max_rate_limit_retries", 3)
+    use_stream = config.get("use_stream", False)
     channel = twitch["channel"]
 
     # --- Token manager ---
@@ -120,6 +121,7 @@ def main():
             token_manager,
             token_bucket,
             moderation_timeout,
+            use_stream,
         ),
     )
     run_thread.start()

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ tokens_per_minute: 200000       # your OpenAI API token per minute rate limit
 moderation_timeout: 60          # how long to wait for OpenAI API to respond before timing out
 max_openai_content_size: 256000 # not to exceed 256000 tokens per request. OpenAI API limit.
 max_rate_limit_retries: 3       # how many times to retry on rate limit errors
+use_stream: false               # stream run events instead of polling
 twitch:                         # Twitch configuration
   server: "irc.chat.twitch.tv"  # Twitch IRC server
   port: 6697                    # Twitch IRC port, 6697 for SSL


### PR DESCRIPTION
## Summary
- add `stream_run` helper to receive run events from OpenAI
- allow `moderate_batch` and `run_worker` to use streaming
- expose `use_stream` config flag and read it in `bot.py`
- document streaming mode in README
- default flag added to `config.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ddbf444748320a2422819f14b81ce