### PR TITLE
Fix IRCv3 capability request format for Twitch

### DIFF
--- a/irc_client.py
+++ b/irc_client.py
@@ -48,7 +48,7 @@ def run_irc_forever(config, token_manager, message_queue=None):
     def on_connect(connection, event):
         # Request IRCv3 tags capability before joining channel
         connection.cap(
-            "REQ", ":twitch.tv/tags", ":twitch.tv/commands", ":twitch.tv/membership"
+            "REQ", ":twitch.tv/tags twitch.tv/commands twitch.tv/membership"
         )
         connection.join(channel)
         print(f"[IRC] Connected and joined {channel}")


### PR DESCRIPTION
## Summary
Fixed the IRCv3 capability request format when connecting to Twitch IRC to use the correct syntax expected by the server.

## Key Changes
- Updated the `cap()` method call to pass capabilities as a single space-separated string instead of multiple separate arguments
- Changed from `"REQ", ":twitch.tv/tags", ":twitch.tv/commands", ":twitch.tv/membership"` to `"REQ", ":twitch.tv/tags twitch.tv/commands twitch.tv/membership"`

## Implementation Details
The IRCv3 capability request protocol expects multiple capabilities to be specified as a single space-separated string in the value parameter, not as separate function arguments. This change ensures the capability negotiation with Twitch IRC servers works correctly, allowing the client to properly request tags, commands, and membership capabilities.

https://claude.ai/code/session_01KjPisvQ11QbNANfpNWpZW5